### PR TITLE
Update exercise133.yaml

### DIFF
--- a/exercise133.yaml
+++ b/exercise133.yaml
@@ -8,7 +8,7 @@
     user: sharon
   tasks:
   - debug: 
-      msg: "{{ '{{ passw }}' | password_hash('sha512','myrandomsalt') }}"
+      msg: "{{ passw | password_hash('sha512','myrandomsalt') }}"
     register: mypass
   - debug:
       var: mypass


### PR DESCRIPTION
Brackets are unnecessary, the wrong password will be generated. In this case, everything works correctly.