### PR TITLE
Fix authorized_keys permissions

### DIFF
--- a/exercise123.yaml
+++ b/exercise123.yaml
@@ -46,6 +46,9 @@
     copy:
       src: /home/ansible/.ssh/id_rsa.pub
       dest: /home/ansible/.ssh/authorized_keys
+      owner: ansible
+      group: ansible
+      mode: 0600
   tags: setuphost
 
 - name: use subscription manager to register and set up repos


### PR DESCRIPTION
It turns out that the aforementioned file will end up with root being the owner and group of that file. This will prevent the ansible user from being able to login using the key. And, also, it will be a very difficult bug to catch. 

This is fixed in this patch.