### PR TITLE
fix exercise131.yaml

### DIFF
--- a/exercise131.yaml
+++ b/exercise131.yaml
@@ -13,9 +13,9 @@
       group: "{{ item.groups }}"
     loop: "{{ users }}"
   - name: allow group members in sudo
-    template:
-      src: exercise131.j2
+    lineinfile:
       dest: /etc/sudoers.d/sudogroups
+      line: "{{ item.groups }} ALL=(ALL:ALL) NOPASSWD:ALL"
       validate: 'visudo -cf %s'
       mode: 0440
     loop: "{{ users }}"


### PR DESCRIPTION
It seems that using a template to loop through several groups in order to add sudo rights does not generate the desired state.  We end up overwriting the file and, in my case, the only entry allows sudo for the students group only. 

If we want all groups to be added to sudo, we need to use lineinfile.