### PR TITLE
Fixed lab82.j2, improved lab82.yaml

### DIFF
--- a/lab82.j2
+++ b/lab82.j2
@@ -1,17 +1,126 @@
----
-- name: configure VSFTPD using a template
-  hosts: all
-  vars:
-    anonymous_enable: yes
-    local_enable: yes
-    write_enable: yes
-    anon_upload_enable: yes
-  tasks:
-  - name: install vsftpd
-    yum:
-      name: vsftpd
-  - name: use template to copy FTP config
-    template:
-      src: vsftpd.j2
-      dest: /etc/vsftpd/vsftpd.conf
+# Example config file /etc/vsftpd/vsftpd.conf
+#
+# The default compiled in settings are fairly paranoid. This sample file
+# loosens things up a bit, to make the ftp daemon more usable.
+# Please see vsftpd.conf.5 for all compiled in defaults.
+#
+# READ THIS: This example file is NOT an exhaustive list of vsftpd options.
+# Please read the vsftpd.conf.5 manual page to get a full idea of vsftpd's
+# capabilities.
+#
+# Allow anonymous FTP? (Beware - allowed by default if you comment this out).
+anonymous_enable={{ anonymous_enable }}
+#
+# Uncomment this to allow local users to log in.
+local_enable={{ local_enable }}
+#
+# Uncomment this to enable any form of FTP write command.
+write_enable={{ write_enable }}
+#
+# Default umask for local users is 077. You may wish to change this to 022,
+# if your users expect that (022 is used by most other ftpd's)
+local_umask=022
+#
+# Uncomment this to allow the anonymous FTP user to upload files. This only
+# has an effect if the above global write enable is activated. Also, you will
+# obviously need to create a directory writable by the FTP user.
+# When SELinux is enforcing check for SE bool allow_ftpd_anon_write, allow_ftpd_full_access
+anon_upload_enable={{ anon_upload_enable }}
+#
+# Uncomment this if you want the anonymous FTP user to be able to create
+# new directories.
+#anon_mkdir_write_enable=YES
+#
+# Activate directory messages - messages given to remote users when they
+# go into a certain directory.
+dirmessage_enable=YES
+#
+# Activate logging of uploads/downloads.
+xferlog_enable=YES
+#
+# Make sure PORT transfer connections originate from port 20 (ftp-data).
+connect_from_port_20=YES
+#
+# If you want, you can arrange for uploaded anonymous files to be owned by
+# a different user. Note! Using "root" for uploaded files is not
+# recommended!
+#chown_uploads=YES
+#chown_username=whoever
+#
+# You may override where the log file goes if you like. The default is shown
+# below.
+#xferlog_file=/var/log/xferlog
+#
+# If you want, you can have your log file in standard ftpd xferlog format.
+# Note that the default log file location is /var/log/xferlog in this case.
+xferlog_std_format=YES
+#
+# You may change the default value for timing out an idle session.
+#idle_session_timeout=600
+#
+# You may change the default value for timing out a data connection.
+#data_connection_timeout=120
+#
+# It is recommended that you define on your system a unique user which the
+# ftp server can use as a totally isolated and unprivileged user.
+#nopriv_user=ftpsecure
+#
+# Enable this and the server will recognise asynchronous ABOR requests. Not
+# recommended for security (the code is non-trivial). Not enabling it,
+# however, may confuse older FTP clients.
+#async_abor_enable=YES
+#
+# By default the server will pretend to allow ASCII mode but in fact ignore
+# the request. Turn on the below options to have the server actually do ASCII
+# mangling on files when in ASCII mode. The vsftpd.conf(5) man page explains
+# the behaviour when these options are disabled.
+# Beware that on some FTP servers, ASCII support allows a denial of service
+# attack (DoS) via the command "SIZE /big/file" in ASCII mode. vsftpd
+# predicted this attack and has always been safe, reporting the size of the
+# raw file.
+# ASCII mangling is a horrible feature of the protocol.
+#ascii_upload_enable=YES
+#ascii_download_enable=YES
+#
+# You may fully customise the login banner string:
+#ftpd_banner=Welcome to blah FTP service.
+#
+# You may specify a file of disallowed anonymous e-mail addresses. Apparently
+# useful for combatting certain DoS attacks.
+#deny_email_enable=YES
+# (default follows)
+#banned_email_file=/etc/vsftpd/banned_emails
+#
+# You may specify an explicit list of local users to chroot() to their home
+# directory. If chroot_local_user is YES, then this list becomes a list of
+# users to NOT chroot().
+# (Warning! chroot'ing can be very dangerous. If using chroot, make sure that
+# the user does not have write access to the top level directory within the
+# chroot)
+#chroot_local_user=YES
+#chroot_list_enable=YES
+# (default follows)
+#chroot_list_file=/etc/vsftpd/chroot_list
+#
+# You may activate the "-R" option to the builtin ls. This is disabled by
+# default to avoid remote users being able to cause excessive I/O on large
+# sites. However, some broken FTP clients such as "ncftp" and "mirror" assume
+# the presence of the "-R" option, so there is a strong case for enabling it.
+#ls_recurse_enable=YES
+#
+# When "listen" directive is enabled, vsftpd runs in standalone mode and
+# listens on IPv4 sockets. This directive cannot be used in conjunction
+# with the listen_ipv6 directive.
+listen=NO
+#
+# This directive enables listening on IPv6 sockets. By default, listening
+# on the IPv6 "any" address (::) will accept connections from both IPv6
+# and IPv4 clients. It is not necessary to listen on *both* IPv4 and IPv6
+# sockets. If you want that (perhaps because you want to listen on specific
+# addresses) then you must run two copies of vsftpd with two configuration
+# files.
+# Make sure, that one of the listen options is commented !!
+listen_ipv6=YES
 
+pam_service_name=vsftpd
+userlist_enable=YES

--- a/lab82.yaml
+++ b/lab82.yaml
@@ -6,9 +6,18 @@
     yum:
       name: vsftpd
       state: installed
+  - name: install firewalld
+    yum:
+      name: firewalld
+      state: installed
   - name: start and enable vsftpd
     service:
       name: vsftpd
+      enabled: yes
+      state: started
+  - name: start and enable firewalld
+    service:
+      name: firewalld
       enabled: yes
       state: started
   - name: open port in firewall
@@ -21,10 +30,10 @@
 - name: configure VSFTPD using a template
   hosts: ansible2.example.com
   vars:
-    anonymous_enable: yes
-    local_enable: yes
-    write_enable: yes
-    anon_upload_enable: yes
+    anonymous_enable: "yes"
+    local_enable: "yes"
+    write_enable: "yes"
+    anon_upload_enable: "yes"
   tasks:
   - name: use template to copy FTP config
     template:
@@ -41,6 +50,7 @@
   - name: set permissions
     file:
       path: /var/ftp/pub
+      state: directory
       mode: '0777'
   - name: set selinux boolean
     seboolean:


### PR DESCRIPTION
Hi,

I suggest the following improvements:
- edited lab82.j2, as it contained no vsftpd.conf content
- added tasks to install and start/enable firewalld, to be sure that dependent tasks do not fail
- enclosed vars passed to template task in quotes (ln. 33-36), as ansible seems to expand the "yes" to a "true", which may produce unwanted results
- added a parameter to the file module (ln. 53), so that the directory gets created, in case it should not exist for whatever reasons